### PR TITLE
Fix small issue in script

### DIFF
--- a/xiaomi.vacuum.gen1/firmwarebuilder/imagebuilder.sh
+++ b/xiaomi.vacuum.gen1/firmwarebuilder/imagebuilder.sh
@@ -113,6 +113,6 @@ else
 	mkdir -p output
 	mv v11_003077_patched.pkg.cpt output/v11_003077.pkg
 	cd output
-	md5sum v11_003077.pkg > output/v11_003077.md5
+	md5sum v11_003077.pkg > v11_003077.md5
 fi
 


### PR DESCRIPTION
avoid the  `./imagebuilder.sh: line 116: output/v11_003077.md5: No such file or directory`  error