### PR TITLE
Plattform-check always detects mac plattform instead of linux

### DIFF
--- a/xiaomi.vacuum.gen1/firmwarebuilder/imagebuilder.sh
+++ b/xiaomi.vacuum.gen1/firmwarebuilder/imagebuilder.sh
@@ -32,12 +32,12 @@ if [[ $OSTYPE == darwin* ]]; then
 	echo "Running on a Mac, adjusting commands accordingly"
 fi
 
-if [ ! -f /usr/bin/ccrypt ] && [ ! IS_MAC ]; then
+if [ ! -f /usr/bin/ccrypt ] && ! $IS_MAC; then
     echo "Ccrypt not found! Please install it (e.g. by apt-get install ccrypt)"
 	exit 1
 fi
 
-if [ ! -f /usr/local/bin/ccrypt ] && [ IS_MAC ]; then
+if [ ! -f /usr/local/bin/ccrypt ] && $IS_MAC; then
     echo "Ccrypt not found! Please install it (e.g. by brew install ccrypt)"
 	exit 1
 fi
@@ -86,7 +86,7 @@ else
 	fi
 	mkdir image
 
-	if [ IS_MAC ]; then
+	if $IS_MAC; then
 		#ext4fuse doesn't support write properly
 		#ext4fuse disk.img image -o force
 		fuse-ext2 disk.img image -o rw+
@@ -104,7 +104,7 @@ else
 	cat ../ssh_host_ed25519_key > ./etc/ssh/ssh_host_ed25519_key
 	cat ../ssh_host_ed25519_key.pub > ./etc/ssh/ssh_host_ed25519_key.pub
 	echo "disable SSH firewall rule"
-	if [ IS_MAC ]; then
+	if $IS_MAC; then
 		# see https://stackoverflow.com/a/21243111
 		sed -i -e '/    iptables -I INPUT -j DROP -p tcp --dport 22/s/^/#/g' ./opt/rockrobo/watchdog/rrwatchdoge.conf
 	else
@@ -151,7 +151,7 @@ else
 	mkdir -p output
 	mv v11_$FIRMWARE_VERSION_patched.pkg.cpt output/v11_$FIRMWARE_VERSION.pkg
 
-	if [ IS_MAC ]; then
+	if $IS_MAC; then
 		md5 output/v11_$FIRMWARE_VERSION.pkg > output/v11_$FIRMWARE_VERSION.md5
 	else
 		md5sum output/v11_$FIRMWARE_VERSION.pkg > output/v11_$FIRMWARE_VERSION.md5


### PR DESCRIPTION
Using test-command on IS_MAC always returns true, since in the way it is used it only checks for non-empty strings. This returns the same value for true and false.
If this is done without the test command, the shell built-ins true and false are used. These return the expected values and make the plattform chekc work properly.