### PR TITLE
Add audio generation script

### DIFF
--- a/xiaomi.vacuum.gen1/audio_generator/audio_de.csv
+++ b/xiaomi.vacuum.gen1/audio_generator/audio_de.csv
@@ -1,0 +1,60 @@
+back_dock_nearby.wav,Konnte Dockingstation nicht erreichen. Bitte Hindernisse entfernen!
+bin_in.wav,Staubbehälter eingesetzt.
+bin_out.wav,Staubbehälter entfernt.
+binout_error10.wav,Staubbehälter ist entfernt. Bitte Filter säubern!
+bl_recovery_bootfailed.wav,Recovery Boot fehlgeschlagen.
+bl_recovery_failed.wav,Recovery fehlgeschlagen.
+bl_recovery_retry.wav,Recovery neuer Versuch.
+bl_recovery_start.wav,Recovery Start.
+bl_recovery_updatefailed.wav,Recovery Update fehlgeschlagen.
+charging.wav,Lade.
+clean_bin.wav,Bitte den Staubbehälter säubern.
+clean_finish.wav,Reinigung abgeschlossen
+error1.wav,"Fehler 1, Versuchen Sie den orangen Kopf der Lasereinheit zu drehen um sicherzustellen, dass dieser nicht blockiert ist."
+error2.wav,"Fehler 2, Reinigen Sie den Bumper und tippen Sie diesen leicht an."
+error3.wav,"Fehler 3, Versuchen Sie den Saugroboter an eine andere Stelle zu bewegen."
+error4.wav,"Fehler 4, Reinigen Sie den Abgrundsensor und bewegen Sie den Roboter an eine andere Stelle."
+error5.wav,"Fehler 5, Entfernen und Reinigen Sie die Hauptbürste."
+error6.wav,"Fehler 6, Entfernen und Reinigen Sie die Seitenbürsten."
+error7.wav,"Fehler 7, Stellen Sie sicher, dass die Räder nicht blockiert sind und stellen Sie den Roboter an eine andere Stelle."
+error8.wav,"Fehler 8, Stellen Sie sicher, dass keine Hindernisse um dem Roboter herum stehen."
+error9.wav,"Fehler 9, Setzen Sie den Staubbehälter sowie Filter ein."
+error10.wav,"Fehler 10, Reinigen oder Ersetzen Sie den Filter."
+error11.wav,"Fehler 11, Starkes magnetisches Feld erkannt. Bewegen Sie den Roboter von der virtuellen Wand weg und versuchen Sie es erneut."
+error12.wav,"Fehler 12, Batterie ist leer. Laden Sie den Staubsaugerroboter."
+error13.wav,"Fehler 13, Laden fehlgeschlagen. Stellen Sie sicher, dass die Ladekontakte sauber sind."
+error14.wav,"Fehler 14, Fehlfunktion des Akkus."
+error15.wav,"Fehler 15, Reinigen Sie den Wandsensor."
+error16.wav,"Fehler 16, Benutzen Sie den Roboter auf einer flachen horizontalen Fläche."
+error17.wav,"Fehler 17, Fehlfunktion der Seitenbürsten. Bitte starten Sie das System neu."
+error18.wav,"Fehler 18, Fehlfunktion des Gebläses. Bitte starten Sie das System neu."
+error19.wav,"Fehler 19, Die Dockingstation ist nicht am Strom angeschlossen."
+error_internal.wav,Ein interner Fehler ist aufgetreten. Starten Sie das System neu.
+findme.wav,"Hey, ich bin hier."
+finish.wav,Reinigung abgeschlossen
+home.wav,Fahre zurück an die Docking Station
+no_power_charging.wav,Akkustand ist gering. Benötige mehr Zeit zum Laden.
+no_power.wav,Akkustand ist gering. Fahre zurück an die Docking Station.
+no_spot_on_dock.wav,Platzieren Sie den Staubsaugerroboter im Zielbereich bevor Sie die Punktreinigung starten.
+pause.wav,Pausiert.
+power_off_rejected.wav,"Bewegen Sie den Roboter von der Docking Station weg, um diesen auszuschalten."
+power_off.wav,Schalte aus.
+power_resume_clean.wav,Betterie geladen. Setze Reinigung fort.
+remote_complete.wav,Verwende Fernsteuerung.
+remote.wav,Verwendung der Fernsteuerung abgeschlossen.
+restart_clean.wav,Position unbekannt. Starte neue Reinigung.
+resume_clean.wav,Setze Reinigung fort.
+resume_home.wav,Lade.
+return_no.wav,Konnte nicht zu dem Startpunkt zurückkehren.
+return_yes.wav,Konnte Dockingstation nicht finden. Platzieren Sie den Roboter näher an der Dockingstation und versuchen Sie es erneut.
+spot.wav,Starte Punktreinigung.
+start.wav,Starte Reinigung.
+stop_spot.wav,Beende Punktreinigung.
+stop.wav,Beende Reinigung.
+sysupd_complete.wav,Update erfolgreich.
+sysupd_failed.wav,Firmwareupdate fehlgeschlagen. Verwende alte Version.
+sysupd_notready.wav,"Versuchen Sie bitte das Update aufzuspielen, wenn der Roboter mindestens zu 20 % geladen ist."
+sysupd_start.wav,Starte Firmwareupdate. Kann 5 bis 10 Minuten dauern.
+sysupd_wip.wav,Warten Sie bitte bis das Update abgeschlossen ist.
+timed_clean.wav,Starte geplante Reinigung.
+wifi_reset.wav,Setze Wlan zurück.

--- a/xiaomi.vacuum.gen1/audio_generator/generate_audio.py
+++ b/xiaomi.vacuum.gen1/audio_generator/generate_audio.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import os
+import csv
+
+output_directory = "generated"
+input_file = "audio_de.csv"
+language = "de"
+# text to speech engine (gtts or espeak)
+engine = "gtts"
+
+# import engine
+if engine == "gtts":
+    from gtts import gTTS
+
+# read input file
+filereader = csv.reader(open(input_file), delimiter=",")
+
+# create output folder
+if not os.path.exists(output_directory):
+    os.makedirs(output_directory)
+
+# generate audio
+for filename, text in filereader:
+    print(filename)
+    path = output_directory + "/" + filename
+    if engine == "gtts":
+        tts = gTTS(text=text, lang=language, slow=False)
+		# save mp3 and convert to mp3
+        tts.save(path + ".mp3")
+        os.system("ffmpeg -hide_banner -loglevel panic -i " + path + ".mp3 " + path)
+        os.remove(path + ".mp3")
+    elif engine == "espeak":
+        os.system("espeak-ng -v " + language + " '" + text + "' -w " + path)


### PR DESCRIPTION
Add an audio generation script for easy generation of new audio files for unsupported languages. Script allows to use espeak-ng or the online google text to speech.

A german language example file is provided. It might need some translation improvements, but I just run out of time.

To add a new language just create a new `audio_??.csv` file and change the parameters of the `generate_audio.py` script