### PR TITLE
change outdated mirobo library to miio

### DIFF
--- a/UPDATE-howto.md
+++ b/UPDATE-howto.md
@@ -1,5 +1,5 @@
 ## Preparation
-1. Install [python-mirobo](https://github.com/ultrara1n/python-mirobo) (python3!)
+1. Install [python-miio](https://github.com/rytilahti/python-miio) (python3!)
 1. Install ccrypt(apt-get install ccrypt)
 1. Create custom image with imagebuilder.sh, Copy MD5 sum
 	* you need to create your own ssh keypair and create an authorized key file


### PR DESCRIPTION
The mirobo library is developed as the more general miio library. The miio library can be used in the same way (see also https://github.com/dgiese/dustcloud/issues/9). Also the mac tutorial is already using it.