### PR TITLE
Reduce the travis git depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down
+git:
+  depth: 1


### PR DESCRIPTION
By reducing the git depth for travis the build speed should be improved, since the newer commits don't contain the big firmware files.