### PR TITLE
Recommend to remove ccrypt package

### DIFF
--- a/disable-UPDATES.md
+++ b/disable-UPDATES.md
@@ -1,15 +1,8 @@
 Firmwareupdates and soundpackages require the command ccrypt to work properly. Any update must be decrypted by that command.
-By renaming it, you technically disable your vacuum's ability to update firmware/install soundpackages.
+By removing `ccrypt`, you technically disable your vacuum's ability to update firmware/install soundpackages.
 
-> mv /usr/bin/ccrypt /usr/bin/ccrypt_
-
-> touch /usr/bin/ccrypt
-
-> chmod +x /usr/bin/ccrypt
+> apt-get remove ccrypt
 
 ### Reverse (to install updates and soundpackages again) 
-Check that /usr/bin/ccrypt_ exists (you do not want to delete your actual copy of ccrypt)
 
-> rm /usr/bin/ccrypt
-
-> mv /usr/bin/ccrypt_ /usr/bin/ccrypt
+> apt-get install ccrypt


### PR DESCRIPTION
Thanks for your wonderful reverse-engineering efforts and very nice documentation on how to get SSH access to the Xiaomi Vacuum 😃!

[The documentation advises users to rename the `ccrypt` binary to `ccrypt_` in order to prevent future firmware updates.](https://github.com/dgiese/dustcloud/blob/master/disable-UPDATES.md) To my mind, it is a cleaner approach to remove the `ccrypt` Debian package through the package manager entirely instead of manually renaming the `ccrypt` binary.

I don’t see any complications right now that removing the `ccrypt` package from the device could lead to.