### PR TITLE
Partial UDP support

### DIFF
--- a/dustcloud/server.py
+++ b/dustcloud/server.py
@@ -264,20 +264,19 @@ class CloudClient:
                             mysocket.send_data_to_cloud(data)
                             return 0
                     elif method == "NONE" and (device_result != "NONE" or device_error != "NONE"):
+                        # client sent a result for a request
                         self.do_log(did, m.data.value, MessageDirection.FromClient)
                         if device_error == "NONE":
                             self.confirm_commands(did, packetid, 1)
                         else:
                             self.confirm_commands(did, packetid, -1)
-                        cmd = {
-                            "id": packetid,
-                            "result": "ok"
-                        }
+
                         if (mysocket.full_cloud_forward == 1) and (packetid not in mysocket.blocked_from_client_list):
                             self.do_log(did, m.data.value, MessageDirection.ToCloud + "(result)")
                             mysocket.send_data_to_cloud(data)
                         if packetid in mysocket.blocked_from_client_list:
                             mysocket.blocked_from_client_list.remove(packetid)
+                        return 0
                     elif method == "_sync.batch_gen_room_up_url":
                         self.do_log(did, m.data.value, MessageDirection.FromClient)
                         # cmd = {

--- a/dustcloud/server.py
+++ b/dustcloud/server.py
@@ -323,19 +323,22 @@ class CloudClient:
                 print("Localtime %s " % datetime.datetime.utcnow())
 
                 if m.data["length"] > 0:
-                    method = m.data.value.get("method", "NONE")
-                    device_result = m.data.value.get("result", "NONE")
-                    device_error = m.data.value.get("error", "NONE")
-                    packetid = m.data.value.get("id", 0)
-                    print("Cloud->%s : messageID: %s Method: %s " % (mysocket.dname, packetid, method))
-                    print("Cloud->%s : Value: %s" % (mysocket.dname, m.data.value))
-                    self.do_log(did, m.data.value, "dustcloud << cloud")
-                    if mysocket.full_cloud_forward == 1 \
-                       and method not in blocked_methods_from_cloud_list \
-                       and packetid not in mysocket.blocked_from_cloud_list:
-                        mysocket.sendmydata(data)  # forward data to client
-                    if packetid in mysocket.blocked_from_client_list:
-                        mysocket.blocked_from_cloud_list.remove(packetid)
+                    if m.data.value:
+                        method = m.data.value.get("method", "NONE")
+                        device_result = m.data.value.get("result", "NONE")
+                        device_error = m.data.value.get("error", "NONE")
+                        packetid = m.data.value.get("id", 0)
+                        print("cloud->%s : messageID: %s Method: %s " % (mysocket.dname, packetid, method))
+                        print("cloud->%s : Value: %s" % (mysocket.dname, m.data.value))
+                        self.do_log(did, m.data.value, "dustcloud << cloud")
+                        if mysocket.full_cloud_forward == 1 \
+                           and method not in blocked_methods_from_cloud_list \
+                           and packetid not in mysocket.blocked_from_cloud_list:
+                            mysocket.sendmydata(data)  # forward data to client
+                        if packetid in mysocket.blocked_from_client_list:
+                            mysocket.blocked_from_cloud_list.remove(packetid)
+                    else:
+                        print("cloud->%s : Couldn't parse message!" % mysocket.dname)
                 else:
                     print("Cloud->%s : Ping-Pong" % mysocket.dname)
                     if (mysocket.forward_to_cloud == 1) or (mysocket.full_cloud_forward == 1):
@@ -412,6 +415,7 @@ class SingleTCPHandler(socketserver.BaseRequestHandler):
                 # print(self.commandcounter)
                 # if queue_return["id"] >= self.commandcounter:
                 if queue_return["id"] >= 0:
+                    print("---------Send message to client {}".format(self.dname))
                     self.commandcounter = queue_return["id"]
                     self.Cloudi.mark_command_as_processed(self.ddid, queue_return["id"])
                     cmd = queue_return

--- a/dustcloud/server.py
+++ b/dustcloud/server.py
@@ -432,7 +432,7 @@ class SingleTCPHandler(socketserver.BaseRequestHandler):
                     print("%s : Value: %s" % (self.dname, msg))
                     # print("< RAW: %s" % binascii.hexlify(c))
                     self.sendmydata(c)
-        print("Close Request")
+        print("Close Connection")
         self.cloud_sock.close()
         self.request.close()
         print(" --------------- Thread-id: %s closed" % thread_id)

--- a/dustcloud/www/show.php
+++ b/dustcloud/www/show.php
@@ -58,8 +58,8 @@ if ($did != "")
 {
 	if ($cmd != "")
 	{
-		# add new cmd to cmdquere with 15 seconds expiration
-		$sql = "INSERT into cmdqueue(did,method,params,expire) VALUES(".$mysqli->real_escape_string($did).",'".$mysqli->real_escape_string($cmd)."','".$mysqli->real_escape_string($params)."',DATE_ADD(NOW(), INTERVAL 15 SECOND))";
+		# add new cmd to cmdquere with 30 seconds expiration
+		$sql = "INSERT into cmdqueue(did,method,params,expire) VALUES(".$mysqli->real_escape_string($did).",'".$mysqli->real_escape_string($cmd)."','".$mysqli->real_escape_string($params)."',DATE_ADD(NOW(), INTERVAL 30 SECOND))";
 		$res = $mysqli->query($sql);
 		if (!$res) {
 			echo "<p>There was an error in query: $sql</p>";

--- a/dustcloud/www/show.php
+++ b/dustcloud/www/show.php
@@ -119,7 +119,7 @@ full_cloud_forward: <input type="submit" name="full_cloud_forward" value="1"><in
 </form>
 <?php
 echo "<hr>";
-$res = $mysqli->query("SELECT * FROM statuslog WHERE did = '".$did."' and direction = 'from_client' ORDER by timestamp DESC");
+$res = $mysqli->query("SELECT * FROM statuslog WHERE did = '".$did."' and direction = 'client >> dustcloud' ORDER by timestamp DESC");
 $res->data_seek(0);
 $row = $res->fetch_assoc();
 		foreach ($row as $key => $value)

--- a/dustcloud/www/showlog.php
+++ b/dustcloud/www/showlog.php
@@ -71,9 +71,9 @@ function prettyPrint( $json )
 }
 
 $longlog = isset($_GET['longlog']) ? $_GET['longlog'] : '0';
+$url1=$_SERVER['REQUEST_URI'];
 if ($longlog == 0)
 {
-    $url1=$_SERVER['REQUEST_URI'];
     header("Refresh: 30; URL=$url1"); ### Be carefull, may contain some security risk
 }
 


### PR DESCRIPTION
Fixed UDP mode partially (no cloud forwarding yet) and some other fixes.

You can now configure server.py slightly:
```
usage: server.py [-h] [-mode {TCP,UDP}] [-redirect <HOST>:<PORT>]
                 [-sport SERVER_PORT]

optional arguments:
  -h, --help            show this help message and exit
  -mode {TCP,UDP}, --server-mode {TCP,UDP}
  -redirect <HOST>:<PORT>, --http-redirect <HOST>:<PORT>
                        Enable http redirection to given address for messages
                        that aren't based on the miio protocol. Off by
                        default. Example: 1.2.3.4:12345.
  -sport SERVER_PORT, --server-port SERVER_PORT
                        Listen port for the server. Defaults to 80 for -mode
                        TCP and 8053 for -mode UDP
```

Also reintroduced http redirection but that is not tested at all.