### PR TITLE
Send manual commands to device immediately

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ requests = "*"
 prompt-toolkit = "*"
 python-miio = ">=0.3.6"
 gtts = "*"
+bottle = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "edc38640040e78ac9588e20e07b5e131b313c566e237d21bcde06dab6a74a718"
+            "sha256": "6f7fbb9a4cd5eb5a3d39121c0d6934eea9c9091315755121303498bb108f130f"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -54,6 +54,12 @@
             ],
             "version": "==17.4.0"
         },
+        "bottle": {
+            "hashes": [
+                "sha256:39b751aee0b167be8dffb63ca81b735bbf1dd0905b3bc42761efedee8f123355"
+            ],
+            "version": "==0.12.13"
+        },
         "certifi": {
             "hashes": [
                 "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
@@ -63,36 +69,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:5d0d7023b72794ea847725680e2156d1d01bc698a9007fccce46d03c904fe093",
-                "sha256:86903c0afab4a3390170aca61f753f5adad8ffff947030719ee44dedc5b68403",
-                "sha256:7d35678a54da0d3f1bc30e3a58a232043753d57c691875b5a75e4e062793bc9a",
-                "sha256:824cac33906be5c8e976f0d950924d88ec058989ef9cd2f77f5cd53cec417635",
-                "sha256:6ca52651f6bd4b8647cb7dee15c82619de3e13490f8e0bc0620830a2245b51d1",
-                "sha256:a183959a4b1e01d6172aeed356e2523ec8682596075aa6cf0003fe08da959a49",
-                "sha256:9532c5bc0108bd0fe43c0eb3faa2ef98a2db60fc0d4019f106b88d46803dd663",
-                "sha256:96652215ef328262b5f1d5647632bd342ac6b31dfbc495b21f1ab27cb06d621d",
-                "sha256:6c99d19225e3135f6190a3bfce2a614cae8eaa5dcaf9e0705d4ccb79a3959a3f",
-                "sha256:12cbf4c04c1ad07124bfc9e928c01e282feac9ec7dd72a18042d4fc56456289a",
-                "sha256:69c37089ccf10692361c8d14dbf4138b00b46741ffe9628755054499f06ed548",
-                "sha256:b8d1454ef627098dc76ccfd6211a08065e6f84efe3754d8d112049fec3768e71",
-                "sha256:cd13f347235410c592f6e36395ee1c136a64b66534f10173bfa4df1dc88f47d0",
-                "sha256:0640f12f04f257c4467075a804a4920a5d07ef91e11c525fc65d715c08231c81",
-                "sha256:89a8d05b96bdeca8fdc89c5fa9469a357d30f6c066262e92c0c8d2e4d3c53cae",
-                "sha256:a67c430a9bde73ae85b0c885fcf41b556760e42ea74c16dc70431a349989b448",
-                "sha256:7a831170b621e98f45ed1d5758325be19619a593924127a0a47af9a72a117319",
-                "sha256:796d0379102e6da5215acfcd20e8e69cca9d97309215b4ce088fe175b1c2f586",
-                "sha256:0fe3b3d571543a4065059d1d3d6d39f4ca6da0f2207ad13547094522e32ead46",
-                "sha256:678135090c311780382b1dd3f828f715583ea8a69687ed053c047d3cec6625d6",
-                "sha256:f4992cd7b4c867f453d44c213ee29e8fd484cf81cfece4b6e836d0982b6fa1cf",
-                "sha256:6d191fb20138fe1948727b20e7b96582b7b7e676135eabf72d910e10bf7bfa65",
-                "sha256:ec208ca16e57904dd7f4c7568665f80b1f7eb7e3214be014560c28def219060d",
-                "sha256:b3653644d6411bf4bd64c1f2ca3cb1b093f98c68439ade5cef328609bbfabf8c",
-                "sha256:f4719d0bafc5f0a67b2ec432086d40f653840698d41fa6e9afa679403dea9d78",
-                "sha256:87f837459c3c78d75cb4f5aadf08a7104db15e8c7618a5c732e60f252279c7a6",
-                "sha256:df9083a992b17a28cd4251a3f5c879e0198bb26c9e808c4647e0a18739f1d11d"
+                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
+                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
+                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
+                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
+                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
+                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
+                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
+                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
+                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
+                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
+                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
+                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
+                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb",
+                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
+                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
+                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
+                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
+                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
+                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
+                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
+                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4"
             ],
             "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==1.11.4"
+            "version": "==1.11.5"
         },
         "chardet": {
             "hashes": [
@@ -110,9 +116,9 @@
         },
         "construct": {
             "hashes": [
-                "sha256:297363860be836d0815ba6b98e6051d952d189c9926d36efca931b725e9529f0"
+                "sha256:9c3f4273e8978b7a5ef17b1a54e8858fb11d0f1e50f3d51d399cce3efc434bf1"
             ],
-            "version": "==2.9.30"
+            "version": "==2.9.31"
         },
         "cryptography": {
             "hashes": [
@@ -141,12 +147,6 @@
                 "sha256:e4d967371c5b6b2e67855066471d844c5d52d210c36c28d49a8507b96e2c5291"
             ],
             "version": "==2.1.4"
-        },
-        "enum-compat": {
-            "hashes": [
-                "sha256:939ceff18186a5762ae4db9fa7bfe017edbd03b66526b798dd8245394c8a4192"
-            ],
-            "version": "==0.0.2"
         },
         "gtts": {
             "hashes": [
@@ -214,10 +214,10 @@
         },
         "python-miio": {
             "hashes": [
-                "sha256:66a17cdd98da08164e0ed2ae260f9cb9fc6448dc7b08b2bbb2cef1b49fb02098",
-                "sha256:c6745d78db370f778936f7f4a1fe2e48043f22d1244147ce1866db823c5dd06c"
+                "sha256:4d954013f1bf36801c09943a7713452ec6d4b44a0b1b00e125a66b9f76a2121a",
+                "sha256:bf010a98659a96f1a6179d61657724dcc36f7666aa14aa67dc6a2c86a1b409a5"
             ],
-            "version": "==0.3.6"
+            "version": "==0.3.7"
         },
         "pytz": {
             "hashes": [
@@ -263,10 +263,10 @@
         },
         "zeroconf": {
             "hashes": [
-                "sha256:6df707b9bb1595800aa31dd18d04e04a80f74278f0c25a18d84278714d89e30b",
-                "sha256:434eab8da9525ae725d6842aae7e59d9ec6580bdc5ae84f3c225240bc6797f7a"
+                "sha256:c2879bbc1365f430f02cfbcca508c57f1237e5fa2526c0b060b8165827b2c59f",
+                "sha256:6e3f1e7b5871e3d1410ac29b9fb85aafc1e2d661ed596b07a6f84559a475efcb"
             ],
-            "version": "==0.19.1"
+            "version": "==0.20.0"
         }
     },
     "develop": {}

--- a/dustcloud/server.py
+++ b/dustcloud/server.py
@@ -28,6 +28,7 @@ import select
 import ast
 import argparse
 import enum
+import bottle
 from miio.protocol import Message
 
 blocked_methods_from_cloud_list = [
@@ -40,6 +41,16 @@ status_methods = ['event.status', 'props', 'event.keepalive', 'event.remove', 'e
                   'event.no_motion', 'event.comfortable']
 cloud_server_address = ('ot.io.mi.com', 80)
 http_redirect_address = None
+
+# dict of devices did -> [name, request_handler]
+devices = {}
+
+
+def get_device(did):
+    try:
+        return devices[did]
+    except KeyError:
+        return None
 
 
 class ServerMode(enum.Enum):
@@ -73,6 +84,7 @@ class CloudClient:
     def __init__(self):
         self.db = pymysql.connect("localhost", "dustcloud", "", "dustcloud")
         self.cursor = self.db.cursor()
+        self.expected_messages = {}
 
     def __del__(self):
         self.db.close()
@@ -170,15 +182,22 @@ class CloudClient:
                 print("{} thats a client hello")
                 # print("< RAW: %s" % binascii.hexlify(serverhello))
                 mysocket.clienthello = data
-                mysocket.sendmydata(serverhello)
+                mysocket.send_data_to_client(serverhello)
             elif data[0:12] == clienthello[0:12]:
                 print("{} thats a long client hello")
                 serverhello = bytes.fromhex("21310020ffffffffffffffff" + timestamp) + data[16:32]
                 # print("< RAW: %s" % binascii.hexlify(serverhello))
                 mysocket.clienthello = data
-                mysocket.sendmydata(serverhello)
+                mysocket.send_data_to_client(serverhello)
             else:
                 did = int.from_bytes(data[8:12], byteorder='big')
+
+                # register socket connection for device to allow sending custom commands outside
+                # the request handler
+                device = get_device(did)
+                if device:
+                    device[1] = mysocket
+
                 try:
                     if self.cursor.execute("SELECT did,name,enckey,forward_to_cloud,full_cloud_forward FROM devices WHERE did = %s", did) == 1:
                         # Fetch all the rows in a list of lists.
@@ -271,6 +290,9 @@ class CloudClient:
                         else:
                             self.confirm_commands(did, packetid, -1)
 
+                        if packetid in self.expected_messages:
+                            self.expected_messages.pop(packetid).set()
+
                         if (mysocket.full_cloud_forward == 1) and (packetid not in mysocket.blocked_from_client_list):
                             self.do_log(did, m.data.value, MessageDirection.ToCloud + "(result)")
                             mysocket.send_data_to_cloud(data)
@@ -313,7 +335,7 @@ class CloudClient:
                     print("%s : prepare response" % dname)
                     print("%s : Value: %s" % (dname, cmd))
                     # print("< RAW: %s" % binascii.hexlify(c))
-                    mysocket.sendmydata(c)
+                    mysocket.send_data_to_client(c)
                 else:
                     print("%s : Ping-Pong" % dname)
                     if (mysocket.forward_to_cloud == 1) or (mysocket.full_cloud_forward == 1):
@@ -321,7 +343,7 @@ class CloudClient:
                         mysocket.send_data_to_cloud(data)
                     else:
                         # print("< RAW: %s" % binascii.hexlify(data))
-                        mysocket.sendmydata(data)  # Ping-Pong
+                        mysocket.send_data_to_client(data)  # Ping-Pong
         else:
             print("Wrong packet size %s %s " % (len(data), int.from_bytes(data[2:4], byteorder='big')))
             return 1
@@ -349,7 +371,7 @@ class CloudClient:
                         if mysocket.full_cloud_forward == 1 \
                            and method not in blocked_methods_from_cloud_list \
                            and packetid not in mysocket.blocked_from_cloud_list:
-                            mysocket.sendmydata(data)  # forward data to client
+                            mysocket.send_data_to_client(data)  # forward data to client
                         if packetid in mysocket.blocked_from_client_list:
                             mysocket.blocked_from_cloud_list.remove(packetid)
                     else:
@@ -358,11 +380,27 @@ class CloudClient:
                     print("%s<-cloud : Ping-Pong" % mysocket.dname)
                     if (mysocket.forward_to_cloud == 1) or (mysocket.full_cloud_forward == 1):
                         # self.do_log(did,"PING-PONG (len=32)", MessageDirection.FromCloud + "(ping)")
-                        mysocket.sendmydata(data)  # forward data to client
+                        mysocket.send_data_to_client(data)  # forward data to client
         else:
             print("Wrong packet size %s %s " % (len(data), int.from_bytes(data[2:4], byteorder='big')))
             return 1
         return 0
+
+    def get_devices(self):
+        try:
+            if self.cursor.execute("SELECT did,name FROM devices"):
+                # Fetch all the rows in a list of lists.
+                results = self.cursor.fetchall()
+                return [[row[0], row[1]] for row in results]
+            else:
+                print("Error: device query error")
+        except Exception:
+            print("Error: unable to fetch devices")
+
+        return []
+
+    def expect_message(self, msgid, ev):
+        self.expected_messages[msgid] = ev
 
 
 def send_pending_commands(connection):
@@ -373,12 +411,10 @@ def send_pending_commands(connection):
     queue_return = connection.Cloudi.get_commands(connection.ddid)
     if queue_return["id"] >= 0:
         print("---------Send message to client {}".format(connection.dname))
-        connection.commandcounter = queue_return["id"]
         connection.Cloudi.mark_command_as_processed(connection.ddid, queue_return["id"])
         cmd = queue_return
-        cmd["id"] = connection.commandcounter
-        connection.blocked_from_client_list.append(
-            cmd["id"])  # add to blocklist to not forward results from my cmds to the cloud
+        # add to blocklist to not forward results from my cmds to the cloud
+        connection.blocked_from_client_list.append(cmd["id"])
         send_ts = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
         header = {'length': 0, 'unknown': 0x00000000,
                   'device_id': connection.device_id,
@@ -393,7 +429,56 @@ def send_pending_commands(connection):
         print("%s : prepare command" % connection.dname)
         print("%s : Value: %s" % (connection.dname, msg))
         # print("< RAW: %s" % binascii.hexlify(c))
-        connection.sendmydata(c)
+        connection.send_data_to_client(c)
+
+
+# function static variable decorator,
+# thanks to https://stackoverflow.com/a/279586
+def static_vars(**kwargs):
+    def decorate(func):
+        for k in kwargs:
+            setattr(func, k, kwargs[k])
+        return func
+    return decorate
+
+
+@static_vars(commandcounter=0)
+def send_manual_command(method, params, connection):
+    cmdid = send_manual_command.commandcounter
+    send_manual_command.commandcounter += 1
+
+    print("---------Send message to client {} {}".format(connection.dname, connection.client_address))
+    cmd = {
+        "id": cmdid,
+        "method": '%s' % method,
+        "params": params,
+        "from": '4'
+    }
+
+    # add to blocklist to not forward results from my cmds to the cloud
+    connection.blocked_from_client_list.append(cmdid)
+
+    # build message
+    send_ts = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
+    header = {'length': 0, 'unknown': 0x00000000,
+              'device_id': connection.device_id,
+              'ts': send_ts}
+    msg = {'data': {'value': cmd},
+           'header': {'value': header},
+           'checksum': 0}
+    connection.Cloudi.do_log(connection.ddid, cmd, MessageDirection.ToClient + "(cmd)")
+    print("Sendtime %s " % send_ts)
+    print("Localtime %s " % datetime.datetime.utcnow())
+    c = Message.build(msg, **connection.ctx)
+    print("%s : prepare command" % connection.dname)
+    print("%s : Value: %s" % (connection.dname, msg))
+
+    # print("< RAW: %s" % binascii.hexlify(c))
+
+    if connection.send_data_to_client_and_wait_for_result(c, cmdid):
+        return cmdid
+    else:
+        return None
 
 
 class SingleTCPHandler(socketserver.BaseRequestHandler):
@@ -424,11 +509,17 @@ class SingleTCPHandler(socketserver.BaseRequestHandler):
         self.cloud_sock.sendall(data)
         return
 
-    def sendmydata(self, data):
+    def send_data_to_client(self, data):
         self.Cloudi.do_log_raw(self.ddid, binascii.hexlify(data), MessageDirection.ToClient)
         if self.request.fileno() < 0:
             return
         self.request.send(data)
+
+    def send_data_to_client_and_wait_for_result(self, data, msgid, timeout=5.0):
+        ev = threading.Event()
+        self.Cloudi.expect_message(msgid, ev)
+        self.send_data_to_client(data)
+        return ev.wait(timeout)
 
     def handle(self):
         thread_id = threading.get_ident()
@@ -551,18 +642,25 @@ class MyUDPHandler(socketserver.BaseRequestHandler):
     ctx = ""
     device_id = ""
     dname = ""
-    commandcounter = 0
     connmode = "udp"
 
     blocked_from_client_list = []
     blocked_from_cloud_list = []
+    Cloudi = CloudClient()
+    Cloudi_lock = threading.Lock()
 
     def send_data_to_cloud(self, data):
         # TODO
         return
 
-    def sendmydata(self, data):
+    def send_data_to_client(self, data):
         self.socket.sendto(data, self.client_address)
+
+    def send_data_to_client_and_wait_for_result(self, data, msgid, timeout=5.0):
+        ev = threading.Event()
+        self.Cloudi.expect_message(msgid, ev)
+        self.send_data_to_client(data)
+        return ev.wait(timeout)
 
     def handle(self):
         # UDP is not connection oriented so the UDPServer will likely create instances
@@ -572,20 +670,19 @@ class MyUDPHandler(socketserver.BaseRequestHandler):
         data = self.request[0].strip()
         self.socket = self.request[1]
 
-        # This creates the CloudClient only if it's not already there, reusing the
-        # existing CloudClient if self already set it up.
-        try:
-            self.Cloudi
-        except AttributeError:
-            self.Cloudi = CloudClient()
+        # keep one single instance of CloudClient for UDP connection
+        # and protect it from multi-threaded access
+        self.Cloudi_lock.acquire()
+        self.Cloudi = MyUDPHandler.Cloudi
 
         thread_id = threading.get_ident()
         print(" --------------- Thread-id: {} ({})".format(thread_id, self))
         print("{}:{} via udp wrote:".format(*self.client_address))
         # print("> RAW: %s" % binascii.hexlify(data))
-        if len(data) < 32:
+        if len(data) == 0:
+            print("Connection closed")
+        elif len(data) < 32:
             print("len < 32, discarding message")
-            return
         else:
             if data[0:2] == bytes.fromhex("2131"):  # Check for magic bytes
                 self.Cloudi.process_data(self, data)
@@ -593,7 +690,7 @@ class MyUDPHandler(socketserver.BaseRequestHandler):
                 print("Unknown message: {}".format(data))
 
         send_pending_commands(self)
-
+        self.Cloudi_lock.release()
         print(" --------------- Thread-id: %s closed" % thread_id)
 
 
@@ -615,6 +712,50 @@ class UDPSimpleServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
 
     def __init__(self, server_address, request_handler_class):
         socketserver.UDPServer.__init__(self, server_address, request_handler_class)
+
+
+http_app = bottle.Bottle()
+
+
+def enable_cors(fn):
+    def _enable_cors(*args, **kwargs):
+        # set CORS headers
+        bottle.response.headers['Access-Control-Allow-Origin'] = '*'
+        bottle.response.headers['Access-Control-Allow-Methods'] = 'GET, POST'
+        bottle.response.headers['Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
+
+        if bottle.request.method != 'OPTIONS':
+            # actual request; reply with the actual response
+            return fn(*args, **kwargs)
+
+    return _enable_cors
+
+
+@http_app.get('/devices')
+@enable_cors
+def get_devices():
+    return {"success": True, "devices": {did: [val[0], val[1] is not None] for did, val in devices.items()}}
+
+
+@http_app.post('/run_command')
+@enable_cors
+def run_command():
+    did = bottle.request.query.did
+    device = get_device(int(did))
+    if device:
+        device_connection = device[1]
+        if device_connection:
+            cmd = bottle.request.forms.get('cmd')
+            params = bottle.request.forms.get('params')
+            msg_id = send_manual_command(cmd, params, device_connection)
+            if msg_id is not None:
+                return {"success": True, "did": did, "cmd": cmd, "params": params, "id": msg_id}
+            else:
+                return {"success": False, "reason": "Failed sending command"}
+        else:
+            return {"success": False, "reason": "Device is not connected"}
+    else:
+        return {"success": False, "reason": "Unknown device"}
 
 
 def get_server_port(args):
@@ -643,7 +784,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-sport", "--server-port",
         type=int, required=False,
-        help="Listen port for the server. Defaults to 80 for -mode TCP and 8053 for -mode UDP")
+        help="Listen port for the server. Defaults to 80 for -mode TCP and 8053 for -mode UDP.")
+    parser.add_argument(
+        "-cmdport", "--command-server-port",
+        type=int, required=False,
+        default=1121,
+        help="Listen port for the command server. Defaults to 1121.")
     args = parser.parse_args()
 
     http_redirect_address = args.http_redirect
@@ -653,6 +799,7 @@ if __name__ == "__main__":
         print("Enabled HTTP redirect to {}:{}".format(*http_redirect_address))
 
     server_port = get_server_port(args)
+    cmd_server_port = args.command_server_port
 
     if args.server_mode == ServerMode.TCP:
         server = TCPSimpleServer(("0.0.0.0", server_port), SingleTCPHandler)
@@ -660,13 +807,20 @@ if __name__ == "__main__":
         server = UDPSimpleServer(("0.0.0.0", server_port), MyUDPHandler)
 
     print("Launching {} server on port {}.".format(args.server_mode, server_port))
+    print("Launching command server on port {}.".format(cmd_server_port))
+
+    devices = {x[0]: [x[1], None] for x in CloudClient().get_devices()}
+
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.start()
 
     try:
-        print("Press CTRL-C to exit.\n")
-        server.serve_forever()
+        http_app.run(host="localhost", port=cmd_server_port);
     except KeyboardInterrupt:
         pass
 
+    http_app.close()
     server.shutdown()
+    server_thread.join()
 
     sys.exit(0)

--- a/dustcloud/www/config.php.dist
+++ b/dustcloud/www/config.php.dist
@@ -4,4 +4,5 @@ const DB_HOST = 'localhost';
 const DB_USER = 'user123';
 const DB_PASS = '';
 const DB_NAME = 'dustcloud';
+const CMD_SERVER = 'http://localhost:1121/';
 ?>

--- a/dustcloud/www/fns.php
+++ b/dustcloud/www/fns.php
@@ -1,0 +1,114 @@
+<?php
+
+function hex2str($hex)
+{
+    $str = '';
+    for ($i = 0; $i < strlen($hex); $i += 2)
+    {
+        $str .= chr(hexdec(substr($hex, $i, 2)));
+    }
+
+    return $str;
+}
+
+function doQueryAndReportFailure($db, $query)
+{
+    $res = $db->query($query);
+    if (!$res)
+    {
+        echo "<p>There was an error in query: $query</p>";
+        echo $db->error;
+    }
+}
+
+function includeStyleSheet()
+{
+    echo '<link rel="stylesheet" href="style.css" type="text/css" />';
+}
+
+function printLastContact($last_contact_str)
+{
+    $last_contact_date = new DateTime($last_contact_str);
+    $now = new DateTime("now");
+    $interval_seconds = $now->getTimestamp() - $last_contact_date->getTimestamp();
+    $interval = $now->diff($last_contact_date);
+    if ($interval_seconds <= 60 && $last_contact_date > 0)
+    {
+        $interval_class = "green";
+    }
+    else
+    {
+        $interval_class = "red";
+    }
+
+    echo 'Last contact: '.$last_contact_str.' <span class="'.$interval_class.'">('.$interval->format('%a days %H:%I:%S ago').')</span><br />';
+}
+
+# taken from https://stackoverflow.com/a/9776726
+function prettyPrint($json)
+{
+    $result = '';
+    $level = 0;
+    $in_quotes = false;
+    $in_escape = false;
+    $ends_line_level = null;
+    $json_length = strlen($json);
+
+    for ($i = 0; $i < $json_length; $i++)
+    {
+        $char = $json[$i];
+        $new_line_level = null;
+        $post = "";
+        if ($ends_line_level !== null)
+        {
+            $new_line_level = $ends_line_level;
+            $ends_line_level = null;
+        }
+        if ($in_escape)
+        {
+            $in_escape = false;
+        }
+        elseif ($char === '"' || $char === "'")
+        {
+            $in_quotes = !$in_quotes;
+        }
+        elseif (! $in_quotes)
+        {
+            switch ($char) {
+                case '}': case ']':
+                    $level--;
+                    $ends_line_level = null;
+                    $new_line_level = $level;
+                    break;
+
+                case '{': case '[':
+                    $level++;
+                    // no break
+                case ',':
+                    $ends_line_level = $level;
+                    break;
+
+                case ':':
+                    $post = " ";
+                    break;
+
+                case " ": case "\t": case "\n": case "\r":
+                    $char = "";
+                    $ends_line_level = $new_line_level;
+                    $new_line_level = null;
+                    break;
+            }
+        }
+        elseif ($char === '\\')
+        {
+            $in_escape = true;
+        }
+        if ($new_line_level !== null)
+        {
+            $result .= "\n".str_repeat("  ", $new_line_level);
+        }
+        $result .= $char.$post;
+    }
+
+    return $result;
+}

--- a/dustcloud/www/fns.php
+++ b/dustcloud/www/fns.php
@@ -32,7 +32,7 @@ function printLastContact($last_contact_str)
     $now = new DateTime("now");
     $interval_seconds = $now->getTimestamp() - $last_contact_date->getTimestamp();
     $interval = $now->diff($last_contact_date);
-    if ($interval_seconds <= 60 && $last_contact_date > 0)
+    if ($interval_seconds <= 60)
     {
         $interval_class = "green";
     }

--- a/dustcloud/www/index.php
+++ b/dustcloud/www/index.php
@@ -12,45 +12,53 @@
 #MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #GNU General Public License for more details.
 
+// Style sheets
+require_once 'fns.php';
+includeStyleSheet();
+
 require_once 'config.php';
 $mysqli = new MySQLi(DB_HOST, DB_USER, DB_PASS, DB_NAME);
-if ($mysqli->connect_errno) {
-    echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
+if ($mysqli->connect_errno)
+{
+    die("Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error);
 }
-echo "connected<br>";
 echo "<a href=\"newdevice.php\">Create new device</a><br><br>";
 $res = $mysqli->query("SELECT did,name,model,mac,fw,last_contact FROM devices ORDER BY model, id ASC");
 
 $res->data_seek(0);
 echo "<table border=1>";
 $first = 0;
-while ($row = $res->fetch_assoc()) {
-	if ($first == 0)
-	{
-		echo "<tr><td></td>";
-		foreach ($row as $key => $value)
-		{
-			echo "<td>".$key."</td>";
-		}
-		echo "<td></td>";
-		echo "</tr>";
-		$first = 1;
-	}
-	echo "<tr>";
+while ($row = $res->fetch_assoc())
+{
+    if ($first == 0)
+    {
+        echo "<tr><td></td>";
+        foreach ($row as $key => $value)
+        {
+            echo "<td>".$key."</td>";
+        }
+        echo "<td></td>";
+        echo "</tr>";
+        $first = 1;
+    }
+    echo "<tr>";
     echo "<td><a href=\"./show.php?did=" . $row['did'] . "\">->" . $row['name'] . "</a></td>\n";
-	foreach ($row as $key => $value)
-	{
-		echo "<td>".$value."</td>";
-	}
-	$date1 = new DateTime("now");
-	$date2 = new DateTime($row['last_contact']);
-	$interval = $date1->diff($date2);
-	if ((($date1->getTimestamp() - $date2->getTimestamp()) <= 60) && ($row['last_contact'] > 0))
-	{$bgcolor="green";}
-	else
-	{$bgcolor="red";}
-	echo "<td bgcolor=".$bgcolor.">".$interval->format('%a days %H:%I:%S ago')."</td>";
-	echo "</tr>";
+    foreach ($row as $key => $value)
+    {
+        echo "<td>".$value."</td>";
+    }
+    $date1 = new DateTime("now");
+    $date2 = new DateTime($row['last_contact']);
+    $interval = $date1->diff($date2);
+    if ((($date1->getTimestamp() - $date2->getTimestamp()) <= 60) && ($row['last_contact'] > 0))
+    {
+        $bgcolor="green";
+    }
+    else
+    {
+        $bgcolor="red";
+    }
+    echo "<td class=".$bgcolor.">".$interval->format('%a days %H:%I:%S ago')."</td>";
+    echo "</tr>";
 }
 echo "</table>";
-?>

--- a/dustcloud/www/show.php
+++ b/dustcloud/www/show.php
@@ -12,8 +12,9 @@
 #MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #GNU General Public License for more details.
 
+require_once 'config.php';
+
 // Header configuration
-$url1 = $_SERVER['REQUEST_URI'];
 $refresh_seconds = isset($_GET['refresh']) ? $_GET['refresh'] : 10;
 if (3 == $refresh_seconds)
 {
@@ -23,8 +24,17 @@ else
 {
     $refresh = 10;
 }
-header("Refresh: $refresh; URL=$url1");
+
+// Build the refresh query url (removing any temporary params like cmd_res)
+$query = $_GET;
+unset($query['cmd_res']);
+unset($query['cmd_res_detail']);
+$new_query = http_build_query($query);
+$refresh_url = $_SERVER['PHP_SELF']."?".$new_query;
+
+header("Refresh: $refresh; URL=$refresh_url");
 ?>
+
 
 <?php
     // Style sheets
@@ -46,7 +56,6 @@ header("Refresh: $refresh; URL=$url1");
     }
 
     // DB connection
-    require_once 'config.php';
     $mysqli = new MySQLi(DB_HOST, DB_USER, DB_PASS, DB_NAME);
     if ($mysqli->connect_errno)
     {
@@ -121,42 +130,114 @@ header("Refresh: $refresh; URL=$url1");
     $res = $mysqli->query("SELECT * FROM statuslog WHERE did = '".$did."' and direction = 'client >> dustcloud' ORDER by timestamp DESC");
     $res->data_seek(0);
     $row = $res->fetch_assoc();
-    foreach ($row as $key => $value)
+    if ($row)
     {
-        echo "$key : $value ";
-        echo "<br>";
+        foreach ($row as $key => $value)
+        {
+            echo "$key : $value ";
+            echo "<br>";
+        }
     }
-    ?>
+    else {
+        echo "No communication available yet.";
+    }
+?>
 <hr />
 
 <!-- Predefined commands -->
-<form action="<?php echo htmlentities($_SERVER['PHP_SELF'])."?did=".$did."&refresh=3"; ?>" method="post">
-    <input type="submit" name="cmd" value="miIO.info"><br>
+<?php
+$cmd_res_request_failure = "RequestFailure";
+$cmd_res_command_failure = "CommandFailure";
+$cmd_res_request_success = "Success";
+?>
+<script>
+function on_request_state_change() {
+    if (this.readyState == 1) {
+            // request is starting, show loader
+            document.getElementById("loader").style.display = 'block';
+        }
+
+        if (this.readyState == 4) {
+            // request is done, hide loader and process result
+            document.getElementById("loader").style.display = 'none';
+            var searchParams = new URLSearchParams(window.location.search);
+            if (this.status == 200) {
+                try {
+                    command_result = JSON.parse(this.responseText);
+                    if (command_result.success) {
+                        cmd_res_detail = JSON.stringify({
+                            id: command_result.id,
+                            cmd: command_result.cmd
+                        });
+                        // command sent to device
+                        searchParams.set('cmd_res','<?php echo $cmd_res_request_success; ?>')
+                        searchParams.set('cmd_res_detail', cmd_res_detail)
+                    } 
+                    else {
+                        // failed to send command to device
+                        searchParams.set('cmd_res','<?php echo $cmd_res_command_failure; ?>')
+                        searchParams.set('cmd_res_detail', command_result.reason)
+                    }
+                } catch(e) {
+                    console.log(e);
+                    searchParams.set('cmd_res','Exception processing result')
+                    searchParams.set('cmd_res_detail', e.toString())
+                }
+            }
+            else {
+                searchParams.set('cmd_res','<?php echo $cmd_res_request_failure; ?>')
+            }
+            // reload page with command result to present it to the user
+            window.location.search = searchParams.toString();
+        }
+}
+
+function send_request(formData) {
+    var xmlhttp = new XMLHttpRequest();
+    xmlhttp.onreadystatechange = on_request_state_change;
+    xmlhttp.open("POST", "<?php echo htmlentities(CMD_SERVER)."run_command?did=".$did; ?>", true);
+    xmlhttp.send(formData);
+}
+
+function send_command(cmd) {
+    var formData = new FormData();
+    formData.set("cmd", cmd);
+    send_request(formData);
+}
+
+function send_form(form_element) {
+    var formData = new FormData(form_element);
+    send_request(formData);
+}
+</script>
+<form>
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="miIO.info"><br>
     VACUUM:
-    <input type="submit" name="cmd" value="get_status">
-    <input type="submit" name="cmd" value="app_start">
-    <input type="submit" name="cmd" value="app_stop">
-    <input type="submit" name="cmd" value="app_pause">
-    <input type="submit" name="cmd" value="app_spot">
-    <input type="submit" name="cmd" value="app_charge">
-    <input type="submit" name="cmd" value="app_rc_start">
-    <input type="submit" name="cmd" value="app_rc_end">
-    <input type="submit" name="cmd" value="find_me"><br>
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_status">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="app_start">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="app_stop">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="app_pause">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="app_spot">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="app_charge">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="app_rc_start">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="app_rc_end">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="find_me">
+    <br>
     VACUUM:
-    <input type="submit" name="cmd" value="get_log_upload_status">
-    <input type="submit" name="cmd" value="get_consumable">
-    <input type="submit" name="cmd" value="get_map_v1">
-    <input type="submit" name="cmd" value="get_clean_summary">
-    <input type="submit" name="cmd" value="get_timer">
-    <input type="submit" name="cmd" value="get_dnd_timer">
-    <input type="submit" name="cmd" value="get_custom_mode">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_log_upload_status">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_consumable">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_map_v1">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_clean_summary">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_timer">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_dnd_timer">
+    <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="get_custom_mode">
     <br>
 </form>
 <!-- Custom commands -->
-<form action="<?php echo htmlentities($_SERVER['PHP_SELF'])."?did=".$did; ?>" method="post">
+<form>
     Method: <input type="input" name="cmd" value="get_status">
     Params: <input type="input" name="params" size="100" value="">
-    <input type="submit" name="submit" value="send command">
+    <input type="button" onClick="javascript:send_form(this.parentNode);" value="send command">
 </form>
 
 <?php
@@ -172,12 +253,52 @@ header("Refresh: $refresh; URL=$url1");
     }
 ?>
 
-<form action="<?php echo htmlentities($_SERVER['PHP_SELF'])."?did=".$did; ?>" method="post">
+<form>
     Method: miIO.ota <input type="hidden" name="cmd" value="miIO.ota">
     Params: 
     <select name="params">
         <option value="">Select...</option>
         <?php echo $options;?>
     </select>
-    <input type="submit" name="submit" value="send command">
+    <input type="button" onClick="javascript:send_form(this.parentNode);" value="send command">
 </form>
+
+<hr />
+<div id="loader" class="loader" style="display:none"></div>
+<?php 
+if (isset($_GET['cmd_res']))
+{
+    $command_result = $_GET['cmd_res'];
+    $command_result_text = "Unknown result";
+    $command_result_text_detail = "";
+    $command_result_class = "";
+
+    if ($command_result == $cmd_res_request_failure) {
+        $command_result_text = "Request to command server failed. Check your configuration!";
+        $command_result_class = "red";
+    }
+    else if ($command_result == $cmd_res_command_failure) {
+        $command_result_text = "Failed to send command to device!";
+        $command_result_class = "red";
+    }
+    else if ($command_result == $cmd_res_request_success) {
+        $command_result_text = "Successful!";
+        $command_result_class = "green";
+    }
+    else {
+        $command_result_text = $command_result;
+    }
+
+    if (isset($_GET['cmd_res_detail']))
+    {
+        $command_result_text_detail = "(".$_GET['cmd_res_detail'].")";
+    }
+?>
+    <div class="command_result ">
+        Result for last command: 
+        <span class="result_value <?php echo $command_result_class; ?>"><?php echo $command_result_text; ?></span>
+        <span class="result_value_detail"><?php echo $command_result_text_detail; ?></span>
+    </div>
+<?php
+}
+?>

--- a/dustcloud/www/showcmdlog.php
+++ b/dustcloud/www/showcmdlog.php
@@ -15,47 +15,50 @@
 $url1=$_SERVER['REQUEST_URI'];
 header("Refresh: 30; URL=$url1"); ### Be carefull, may contain some security risk
 
+// Style sheets
+require_once 'fns.php';
+includeStyleSheet();
+
 if (!isset($_GET['did']))
 {
-	die("no did set");
-}else{
-	if (filter_var($_GET['did'], FILTER_VALIDATE_INT) === false) {
-		die('You must enter a valid integer for did!');
-	}
-	$did = $_GET['did'];
+    die("no did set");
+}
+else
+{
+    if (filter_var($_GET['did'], FILTER_VALIDATE_INT) === false)
+    {
+        die('You must enter a valid integer for did!');
+    }
+    $did = $_GET['did'];
 }
 
 require_once 'config.php';
 $mysqli = new MySQLi(DB_HOST, DB_USER, DB_PASS, DB_NAME);
-if ($mysqli->connect_errno) {
+if ($mysqli->connect_errno)
+{
     echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
 }
 echo "<a href=\"index.php\">Index</a><br>";
 $res = $mysqli->query("SELECT * FROM devices WHERE did = '".$did."'");
 
 $res->data_seek(0);
-while ($row = $res->fetch_assoc()) {
-    echo "<a href=\"./show.php?did=" . $row['did'] . "\">" . $row['name'] . "(did:" . $row['did'] . ")</a><br>Last contact: " . $row['last_contact'];
-	$date1 = new DateTime("now");
-	$date2 = new DateTime($row['last_contact']);
-	$interval = $date1->diff($date2);
-	echo " (".$interval->format('%a days %H:%I:%S ago').")";
-	echo "<br>\n";
+while ($row = $res->fetch_assoc())
+{
+    echo "<a href=\"./show.php?did=" . $row['did'] . "\">" . $row['name'] . "(did:" . $row['did'] . ")</a><br>";
+    
+    printLastContact($row['last_contact']);
 }
 echo "<hr>";
 $res = $mysqli->query("SELECT * FROM cmdqueue WHERE did = '".$did."' ORDER BY CMDID DESC LIMIT 100");
 $res->data_seek(0);
 while ($row = $res->fetch_assoc())
 {
-		foreach ($row as $key => $value)
-	{
-		echo "$key : $value ";
-		echo "<br>";
-	}
-	echo "<hr>";
+    foreach ($row as $key => $value)
+    {
+        echo "$key : $value ";
+        echo "<br>";
+    }
+    echo "<hr>";
 }
 
-
 echo "<hr>";
-
-?>

--- a/dustcloud/www/showlog.php
+++ b/dustcloud/www/showlog.php
@@ -12,64 +12,6 @@
 #MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #GNU General Public License for more details.
 
-# taken from https://stackoverflow.com/a/9776726
-function prettyPrint( $json )
-{
-    $result = '';
-    $level = 0;
-    $in_quotes = false;
-    $in_escape = false;
-    $ends_line_level = NULL;
-    $json_length = strlen( $json );
-
-    for( $i = 0; $i < $json_length; $i++ ) {
-        $char = $json[$i];
-        $new_line_level = NULL;
-        $post = "";
-        if( $ends_line_level !== NULL ) {
-            $new_line_level = $ends_line_level;
-            $ends_line_level = NULL;
-        }
-        if ( $in_escape ) {
-            $in_escape = false;
-        } else if( $char === '"' || $char === "'") {
-            $in_quotes = !$in_quotes;
-        } else if( ! $in_quotes ) {
-            switch( $char ) {
-                case '}': case ']':
-                    $level--;
-                    $ends_line_level = NULL;
-                    $new_line_level = $level;
-                    break;
-
-                case '{': case '[':
-                    $level++;
-                case ',':
-                    $ends_line_level = $level;
-                    break;
-
-                case ':':
-                    $post = " ";
-                    break;
-
-                case " ": case "\t": case "\n": case "\r":
-                    $char = "";
-                    $ends_line_level = $new_line_level;
-                    $new_line_level = NULL;
-                    break;
-            }
-        } else if ( $char === '\\' ) {
-            $in_escape = true;
-        }
-        if( $new_line_level !== NULL ) {
-            $result .= "\n".str_repeat( "  ", $new_line_level );
-        }
-        $result .= $char.$post;
-    }
-
-    return $result;
-}
-
 $longlog = isset($_GET['longlog']) ? $_GET['longlog'] : '0';
 $url1=$_SERVER['REQUEST_URI'];
 if ($longlog == 0)
@@ -77,57 +19,65 @@ if ($longlog == 0)
     header("Refresh: 30; URL=$url1"); ### Be carefull, may contain some security risk
 }
 
+// Style sheets
+require_once 'fns.php';
+includeStyleSheet();
+
 if (!isset($_GET['did']))
 {
-	die("no did set");
-}else{
-	if (filter_var($_GET['did'], FILTER_VALIDATE_INT) === false) {
-		die('You must enter a valid integer for did!');
-	}
-	$did = $_GET['did'];
+    die("no did set");
+}
+else
+{
+    if (filter_var($_GET['did'], FILTER_VALIDATE_INT) === false)
+    {
+        die('You must enter a valid integer for did!');
+    }
+    $did = $_GET['did'];
 }
 
 require_once 'config.php';
 $mysqli = new MySQLi(DB_HOST, DB_USER, DB_PASS, DB_NAME);
-if ($mysqli->connect_errno) {
+if ($mysqli->connect_errno)
+{
     echo "Failed to connect to MySQL: (" . $mysqli->connect_errno . ") " . $mysqli->connect_error;
 }
 echo "<a href=\"index.php\">Index</a><br>";
-$res = $mysqli->query("SELECT * FROM devices WHERE did = '".$did."'");
 
+
+$res = $mysqli->query("SELECT * FROM devices WHERE did = '".$did."'");
 $res->data_seek(0);
-while ($row = $res->fetch_assoc()) {
-    echo "<a href=\"./show.php?did=" . $row['did'] . "\">" . $row['name'] . "(did:" . $row['did'] . ")</a><br>Last contact: " . $row['last_contact'];
-	$date1 = new DateTime("now");
-	$date2 = new DateTime($row['last_contact']);
-	$interval = $date1->diff($date2);
-	echo " (".$interval->format('%a days %H:%I:%S ago').")";
-	echo "<br>\n";
+while ($row = $res->fetch_assoc())
+{
+    echo "<a href=\"./show.php?did=" . $row['did'] . "\">" . $row['name'] . "(did:" . $row['did'] . ")</a><br>";
+    
+    printLastContact($row['last_contact']);
 }
 echo "<a href=\"".$url1."&longlog=1\">2000 messages without refresh</a><br>";
 echo "<hr>";
 if ($longlog == 1)
 {
-	$res = $mysqli->query("SELECT * FROM statuslog WHERE did = '".$did."' ORDER by id DESC LIMIT 2000");
-}else
+    $res = $mysqli->query("SELECT * FROM statuslog WHERE did = '".$did."' ORDER by id DESC LIMIT 2000");
+}
+else
 {
-	$res = $mysqli->query("SELECT * FROM statuslog WHERE did = '".$did."' ORDER by id DESC LIMIT 100");
+    $res = $mysqli->query("SELECT * FROM statuslog WHERE did = '".$did."' ORDER by id DESC LIMIT 100");
 }
 $res->data_seek(0);
 while ($row = $res->fetch_assoc())
 {
-		foreach ($row as $key => $value)
-	{
-	    if ($key == "data")
-	    {
-	        $value = prettyPrint( $value );
-	        echo "$key : <pre>$value</pre>";
-	    }else
-	    {
-		    echo "$key : $value ";
-		    echo "<br>";
-	    }
-	}
-	echo "<hr>";
+    foreach ($row as $key => $value)
+    {
+        if ($key == "data")
+        {
+            $value = prettyPrint($value);
+            echo "$key : <pre>$value</pre>";
+        }
+        else
+        {
+            echo "$key : $value ";
+            echo "<br>";
+        }
+    }
+    echo "<hr>";
 }
-?>

--- a/dustcloud/www/style.css
+++ b/dustcloud/www/style.css
@@ -3,9 +3,23 @@
 }
 
 .green {
-    background-color: green
+    background-color: lightgreen
 }
 
 .red {
-    background-color: red
+    background-color: lightcoral
+}
+
+.loader {
+    border: 16px solid #f3f3f3; /* Light grey */
+    border-top: 16px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }

--- a/dustcloud/www/style.css
+++ b/dustcloud/www/style.css
@@ -1,0 +1,11 @@
+.device_info {
+    margin-left: 40px;
+}
+
+.green {
+    background-color: green
+}
+
+.red {
+    background-color: red
+}


### PR DESCRIPTION
Experimented a bit with a JSON-HTTP API that server.py exposes to be able to send commands to the device immediately with feedback. Dustcloud web interface now uses AJAX to interact with the new API.
This adds a new config entry to config.php.dist so we probably need a documentation update too.

Works pretty well for me but I'd like to have other opinions on this.

Ideally, every functionality that dustcloud web interface currently provides will be moved to the JSON API so that server.py is the only one to interact with the database. This would separate the presentation part from the data and would allow developing more apps without having to directly connect to the db.