### PR TITLE
imagebuilder: Wait for umount to succeed

### DIFF
--- a/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
+++ b/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
@@ -201,7 +201,11 @@ echo "$TIMEZONE" > ./etc/timezone
 cp ../sounds/*.wav ./opt/rockrobo/resources/sounds/prc/
 
 cd ..
-umount image
+while [ `umount image; echo $?` -ne 0 ]; do
+    echo "waiting for unmount..."
+    sleep 2
+done
+
 rm -rf image
 rm -rf sounds
 rm -f ssh_host_*


### PR DESCRIPTION
The imagebuilder script fails on ubuntu because the umount result is not checked and the script tries to pack the not fully written image. This PR adds a check for umount and tries it again after two seconds if it fails.
Tested on Ubuntu 17.10.