### PR TITLE
Exclude generated audio files from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ssh_host_rsa_key.pub
 *.md5
 config.php
 settings.json
+xiaomi.vacuum.gen1/audio_generator/generate*
 
 # IDE project files
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ ssh_host_rsa_key.pub
 *.md5
 config.php
 settings.json
-xiaomi.vacuum.gen1/audio_generator/generate*
+devices/xiaomi.vacuum/audio_generator/generate*
 
 # IDE project files
 .idea


### PR DESCRIPTION
I was annoyed that git always tried to add the generated audio files for the robot.