### PR TITLE
fixed readlink problems on mac

### DIFF
--- a/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
+++ b/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
@@ -14,8 +14,6 @@
 
 #You should have received a copy of the GNU General Public License
 #along with this program. If not, see <http://www.gnu.org/licenses/>.
-# Preparation:
-# place english.pkg and v11_<fw_version>.pkg (e.g. v11_003077.pkg) in this folder
 #
 
 if [[ $EUID -ne 0 ]]; then
@@ -40,9 +38,18 @@ if [ ! -f /usr/local/bin/ccrypt -a "$IS_MAC" = true ]; then
 	exit 1
 fi
 
+# see https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+readlink -f imagebuilder.sh 2> /dev/null
+if [[ $? -eq 0 ]]; then
+    echo "compatible readlink found!"
+else
+    echo "readlink from coreutils package not found! Please install it first (e.g. by brew install coreutils)"
+    exit 1
+fi
+
 if [[ $# -eq 0 ]]; then
 	cat << EOF
-usage: sudo ./firmwarebuilder -f v11_003094.pkg [-s english.pkg] [-k id_rsa.pub ] [ -t Europe/Berlin ] [--disable-xiaomi]
+usage: sudo ./imagebuilder.sh -f v11_003094.pkg [-s english.pkg] [-k id_rsa.pub ] [ -t Europe/Berlin ] [--disable-xiaomi]
 
 Options:
   -f, --firmware            path to firmware file


### PR DESCRIPTION
The imagebuilder.sh script was broken for mac users since the used readlink from mac os doesn't know the -f option. So each time it would fail and complain about this. I've added a check so that it will complain before it starts its work:

```
(dustcloud-xEukcPtV) bash-3.2$ sudo ./imagebuilder.sh
Running on a Mac, adjusting commands accordingly
readlink from coreutils package not found! Please install it (e.g. by brew install coreutils)
```

After you've installed coreutils (don't forget to follow the instructions about adding the package to the PATH:

```
(dustcloud-xEukcPtV) bash-3.2$ sudo ./imagebuilder.sh
Running on a Mac, adjusting commands accordingly
/Users/rudelm/git/dustcloud/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
compatible readlink found!
usage: sudo ./imagebuilder.sh -f v11_003094.pkg [-s english.pkg] [-k id_rsa.pub ] [ -t Europe/Berlin ] [--disable-xiaomi]

Options:
  -f, --firmware            path to firmware file
  -s, --soundfile           path to sound file
  -k, --public-key          path to ssh public key to be added to authorized_keys file
                            if need to add multiple keys set -k as many times as you need:
                            -k ./local_key.pub -k ~/.ssh/id_rsa.pub -k /root/ssh/id_rsa.pub
  -t, --timezone            timezone to be used in vacuum
  --disable-xiaomi          disable xiaomi servers using hosts file

Each parameter that takes a file as an argument accepts path in any form

Report bugs to: https://github.com/dgiese/dustcloud/issues
```