### PR TITLE
added reference to instructions in the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Welcome to our repository for hacking and rooting of the Xiaomi Smart Home Devic
 
 We moved the documentation of the devices (photos, datasheets, uart logs, etc) to a new repo [dustcloud-documentation](https://github.com/dgiese/dustcloud-documentation)
 
-Please take a look at the Dustcloud Wiki: (https://github.com/dgiese/dustcloud/wiki)
+Please take a look at the Dustcloud Wiki, which also contains instructions on how to root and flash your device: (https://github.com/dgiese/dustcloud/wiki)
 
 # Talks
 


### PR DESCRIPTION
It is not immediately clear, where to find instructions on how to root and flash your device when accessing the dustcloud repository. It would be helpful if this was stated on the "landing page".