### PR TITLE
Show live vaccum navigation map

### DIFF
--- a/dustcloud/build_map.py
+++ b/dustcloud/build_map.py
@@ -1,0 +1,119 @@
+"""
+#!/usr/bin/env python3
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+"""
+import argparse
+import io
+from PIL import Image, ImageDraw, ImageChops
+
+
+def build_map(slam_log_data, map_image_data):
+    """
+    Parses the slam log to get the vacuum path and draws the path into
+    the map. Returns the new map as a BytesIO.
+
+    Thanks to CodeKing for the algorithm!
+    https://github.com/dgiese/dustcloud/issues/22#issuecomment-367618008
+    """
+    map_image = Image.open(io.BytesIO(map_image_data))
+    map_image = map_image.convert('RGBA')
+
+    # calculate center of the image
+    center_x = map_image.size[0] / 2
+    center_y = map_image.size[0] / 2
+
+    # rotate image by -90°
+    map_image = map_image.rotate(-90)
+
+    red = (255, 0, 0, 255)
+    grey = (125, 125, 125, 255)  # background color
+    transparent = (0, 0, 0, 0)
+
+    # prepare for drawing
+    draw = ImageDraw.Draw(map_image)
+
+    # loop each line of slam log
+    prev_pos = None
+    for line in slam_log_data.split("\n"):
+        # find positions
+        if 'estimate' in line:
+            d = line.split('estimate')[1].strip()
+
+            # extract x & y
+            y, x, z = map(float, d.split(' '))
+
+            # set x & y by center of the image
+            # 20 is the factor to fit coordinates in in map
+            x = center_x + (x * 20)
+            y = center_y + (y * 20)
+
+            pos = (x, y)
+            if prev_pos:
+                draw.line([prev_pos, pos], red)
+            prev_pos = pos
+
+    # draw current position
+    def ellipsebb(x, y):
+        return x-3, y-3, x+3, y+3
+    draw.ellipse(ellipsebb(x, y), red)
+
+    # rotate image back by 90°
+    map_image = map_image.rotate(90)
+
+    # crop image
+    bgcolor_image = Image.new('RGBA', map_image.size, grey)
+    cropbox = ImageChops.subtract(map_image, bgcolor_image).getbbox()
+    map_image = map_image.crop(cropbox)
+
+    # and replace background with transparent pixels
+    pixdata = map_image.load()
+    for y in range(map_image.size[1]):
+        for x in range(map_image.size[0]):
+            if pixdata[x, y] == grey:
+                pixdata[x, y] = transparent
+
+    temp = io.BytesIO()
+    map_image.save(temp, format="png")
+    return temp
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="""
+Process the runtime logs of the vacuum (SLAM_fprintf.log, navmap*.ppm from /var/run/shm)
+and draw the path into the map. Outputs the map as a PNG image.
+    """)
+
+    parser.add_argument(
+        "-slam",
+        default="SLAM_fprintf.log",
+        required=False)
+    parser.add_argument(
+        "-map",
+        required=True)
+    parser.add_argument(
+        "-out",
+        required=False)
+    args = parser.parse_args()
+
+    with open(args.slam) as slam_log:
+        with open(args.map, 'rb') as mapfile:
+            augmented_map = build_map(slam_log.read(), mapfile.read(), )
+
+    out_path = args.out
+    if not out_path:
+        out_path = args.map[:-4] + ".png"
+    if not out_path.endswith(".png"):
+        out_path += ".png"
+
+    with open(out_path, 'wb') as out:
+        out.write(augmented_map.getvalue())

--- a/dustcloud/upload_map.sh
+++ b/dustcloud/upload_map.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Author: Jens Schmer
+# Copyright 2017 by Jens Schmer
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+# This script takes the device id, SLAM log and runtime map of the
+# vacuum and sends it to the dustcloud server for processing.
+DUSTCLOUD_SERVER=192.168.xx.yy
+DUSTCLOUD_PORT=80
+
+DEVICE_CONF=/mnt/data/miio/device.conf
+SLAM_LOG=/var/run/shm/SLAM_fprintf.log
+MAP_FILES=$(find /var/run/shm/ -iname '*.ppm')
+set -- $MAP_FILES
+MAP_FILE=$1
+
+if [ ! -f $DEVICE_CONF ]; then
+    echo "$DEVICE_CONF missing..."
+    exit 0
+fi
+if [ ! -f $SLAM_LOG ]; then
+    echo "$SLAM_LOG missing..."
+    exit 0
+fi
+if [ -z "$MAP_FILE" ] || [ ! -f $MAP_FILE ]; then
+    echo "Map file missing..."
+    exit 0
+fi
+
+echo SLAM_LOG=$SLAM_LOG
+echo MAP_FILE=$MAP_FILE
+
+## Gather all data in a file
+
+head -n1 $DEVICE_CONF > payload_tmp
+printf "SLAM=%s\n" `stat --printf="%s" $SLAM_LOG` >> payload_tmp
+cat $SLAM_LOG >> payload_tmp
+printf "MAP=%s\n" `stat --printf="%s" $MAP_FILE` >> payload_tmp
+cat $MAP_FILE >> payload_tmp
+
+# Prepend magic and size to payload
+FULL_SIZE=`stat --printf="%s" payload_tmp`
+printf "ROCKROBO_MAP__\n%016d\n" $FULL_SIZE > payload
+cat payload_tmp >> payload
+
+## and send it to the dustcloud server
+cat payload | nc -w 2 $DUSTCLOUD_SERVER $DUSTCLOUD_PORT

--- a/dustcloud/www/show.php
+++ b/dustcloud/www/show.php
@@ -209,6 +209,24 @@ function send_form(form_element) {
     var formData = new FormData(form_element);
     send_request(formData);
 }
+
+function get_map()
+{
+    var xmlhttp = new XMLHttpRequest();
+    xmlhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            map_result = JSON.parse(this.responseText);
+            if (map_result.success) {
+                map_data = map_result.imagedata
+                document.getElementById('map').src = "data:image/png;base64,"+map_data
+            }
+            setTimeout(get_map, 4000);
+        }
+    };
+    xmlhttp.open("POST", "<?php echo htmlentities(CMD_SERVER)."get_map?did=".$did; ?>", true);
+    xmlhttp.send();
+}
+get_map();
 </script>
 <form>
     <input type="button" onClick="javascript:send_command(this.value);" name="cmd" value="miIO.info"><br>
@@ -302,3 +320,4 @@ if (isset($_GET['cmd_res']))
 <?php
 }
 ?>
+<img id="map"></img>

--- a/dustcloud/www/style.css
+++ b/dustcloud/www/style.css
@@ -3,11 +3,11 @@
 }
 
 .green {
-    background-color: lightgreen
+    background-color: lightgreen;
 }
 
 .red {
-    background-color: lightcoral
+    background-color: lightcoral;
 }
 
 .loader {
@@ -22,4 +22,10 @@
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+#map {
+    background-color: blue;
+    max-width: 1024px;
+    max-height: 1024px
 }


### PR DESCRIPTION
This needs a helper script on the vacuum to periodically send the runtime map
and SLAM log to the dustcloud server which in turn provides an API
to display the processed image in the dustcloud web UI.

Example for periodically sending the map to the dustcloud server:
$ watch -n5 ./upload_map.sh

This probably has still room for improvement though :-)