### PR TITLE
firmwarebuilder: Let the tar_extra_file.sh do log hygiene

### DIFF
--- a/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
+++ b/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
@@ -311,9 +311,11 @@ if [ "$DISABLE_LOGS" = true ]; then
     sed -i -E 's/(UPLOAD_METHOD=)([0-9]+)/\10/' ./opt/rockrobo/rrlog/rrlog.conf
     sed -i -E 's/(UPLOAD_METHOD=)([0-9]+)/\10/' ./opt/rockrobo/rrlog/rrlogmt.conf
 
+    # Let the script cleanup logs
+    sed -i 's/nice.*//' ./opt/rockrobo/rrlog/tar_extra_file.sh
+
     # Add exit 0
     sed -i '/^\#!\/bin\/bash$/a exit 0' ./opt/rockrobo/rrlog/misc.sh
-    sed -i '/^\#!\/bin\/bash$/a exit 0' ./opt/rockrobo/rrlog/tar_extra_file.sh
     sed -i '/^\#!\/bin\/bash$/a exit 0' ./opt/rockrobo/rrlog/toprotation.sh
     sed -i '/^\#!\/bin\/bash$/a exit 0' ./opt/rockrobo/rrlog/topstop.sh
 


### PR DESCRIPTION
The tar_extra_file.sh also resets log file and deletes files from log rotate, we should allow to do this clean, so just remove the command which create tarballs or gzip files.