### PR TITLE
fix calling imagebuilder.sh with relative path

### DIFF
--- a/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
+++ b/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh
@@ -141,7 +141,7 @@ case $key in
 esac
 done
 
-BASEDIR=$(dirname "$0")
+BASEDIR=$(readlink -f $(dirname "$0"))
 echo "Scriptpath: $BASEDIR"
 
 


### PR DESCRIPTION
Calling `imagebuilder.sh` with a relative path leads to errors when copying template files, e.g. when using `--unprovisioned` parameter.

Command:

    sudo ../dustcloud/devices/xiaomi.vacuum/firmwarebuilder/imagebuilder.sh -f v11_001518.pkg -s english.pkg -k id_rsa.pub --unprovisioned wpa2psk --ssid wlan_ssid --psk secure_passphrase

Output:

    [...]
    implementing unprovisioned mode
    Wifimode: wpa2psk
    cp: cannot stat '../dustcloud/devices/xiaomi.vacuum/firmwarebuilder/unprovisioned/start_wifi.sh': No such file or directory
    chmod: cannot access './opt/unprovisioned/start_wifi.sh': No such file or directory
    cp: cannot stat '../dustcloud/devices/xiaomi.vacuum/firmwarebuilder/unprovisioned/rc.local': No such file or directory
    cp: cannot stat '../dustcloud/devices/xiaomi.vacuum/firmwarebuilder/unprovisioned/wpa_supplicant.conf.wpa2psk': No such file or directory
    sed: can't read ./opt/unprovisioned/wpa_supplicant.conf: No such file or directory
    sed: can't read ./opt/unprovisioned/wpa_supplicant.conf: No such file or directory
    [...]