### PR TITLE
refactored start_wifi.sh to work on gen2 robots

### DIFF
--- a/devices/xiaomi.vacuum/firmwarebuilder/unprovisioned/start_wifi.sh
+++ b/devices/xiaomi.vacuum/firmwarebuilder/unprovisioned/start_wifi.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-file="/opt/unprovisioned/wpa_supplicant.conf"
-if [ ! -f "$file" ]
+config="/opt/unprovisioned/wpa_supplicant.conf"
+log="/opt/unprovisioned/wpa_supplicant.log"
+
+if [ ! -r "$config" ]
 then
-    echo "$0: File '${file}' not found."
+    echo "$0: File '${config}' not found." > "$log"
 else
     #add enough time to fix wrong wireless settings
     sleep 200
 
     #disable accesspoint
-    ifdown wlan0 > /dev/null 2>&1
-    ifconfig wlan0 down > /dev/null 2>&1
-    killall hostapd >/dev/null 2>&1
-    iw mon.wlan0 del >/dev/null 2>&1
-    create_ap --stop wlan0 > /dev/null 2>&1
-    killall wpa_supplicant >/dev/null 2>&1
-    killall dhclient >/dev/null 2>&1
+    echo "Stopping AP..." > "$log"
+    create_ap --stop wlan0 >> "$log" 2>&1
+    echo "Killing leftover AP daemons..." >> "$log"
+    killall hostapd >> "$log" 2>&1
 
     #login to your network
-    ifconfig wlan0 up >/dev/null 2>&1
-    /sbin/wpa_supplicant -s -B -P /var/run/wpa_supplicant_1.wlan0.pid -i wlan0 -D nl80211,wext -c /mnt/data/unprovisioned/wpa_supplicant.conf -C /var/run/wpa_supplicant >/dev/null 2>&1
-    dhclient wlan0 >/dev/null 2>&1
+    echo "Starting WPA supplicant background process..." >> "$log"
+    /sbin/wpa_supplicant -B -iwlan0 -Dnl80211 -c"$config" >> "$log" 2>&1
+    echo "Requesting IP and network settings from DHCP server..." >> "$log"
+    dhclient wlan0 >> "$log" 2>&1
 fi


### PR DESCRIPTION
The current version of the `start_wifi.sh` script for configuring WPA2-PSK did not work on my gen2 robot. I refactored the script and it now works on my robot.

I think this should be tested on gen1 robots before merging.

- added logging to file for debug purposes
- removed deprecated and obsolete calls to `ifdown` and `ifconfig`
- fixed `wpa_supplicant` call (removed explicit PID file creation and unused `-C` ctrl_interface socket parameter)